### PR TITLE
Don't automatically install libraries and headers if included as subproject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
+cmake_policy(SET CMP0127 NEW) # <depends> syntax in cmake_dependent_option() is properly formatted for both old and new behavior.
 
 set(LANGUAGES C)
 if(BUILD_TESTING)
@@ -11,10 +12,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(PROJECTM_EVAL_FLOAT_SIZE "8" CACHE STRING "Byte size of floating-point numbers. 8 to use double, 4 to use float. Default is 8.")
 
+include(CMakeDependentOption)
+
 option(ENABLE_FAST_MATH "Enables aggressive math optimizations like -ffast-math to compile faster code. Applied to Release and RelWithDebInfo configurations only." ON)
 option(BUILD_NS_EEL_SHIM "Build and install the ns-eel2 compatibility API shim." OFF)
 option(BUILD_BENCHMARKS "Build benchmarks. Requires Google Benchmark." OFF)
-
 if(NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 8 AND NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 4)
     message(FATAL_ERROR "PROJECTM_EVAL_FLOAT_SIZE must be set to either 4 (use floats) or 8 (use doubles).")
 endif()
@@ -23,6 +25,8 @@ project(projectm-eval
         VERSION 1.0.0
         LANGUAGES ${LANGUAGES} # Using "enable_language(CXX)" in the test dir will NOT work properly!
         )
+
+cmake_dependent_option(ENABLE_PROJECTM_EVAL_INSTALL "Enable installing projectm-eval libraries and headers." OFF "NOT projectm-eval_IS_TOP_LEVEL" ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/ns-eel2-shim/CMakeLists.txt
+++ b/ns-eel2-shim/CMakeLists.txt
@@ -1,65 +1,69 @@
 add_library(projectM_ns-eel2 STATIC
-        ns-eel.c
-        ns-eel.h
-        )
+            ns-eel.c
+            ns-eel.h
+            )
 
 target_compile_definitions(projectM_ns-eel2
-        PUBLIC
-        EEL_F_SIZE=${PROJECTM_EVAL_FLOAT_SIZE}
-        )
+                           PUBLIC
+                           EEL_F_SIZE=${PROJECTM_EVAL_FLOAT_SIZE}
+                           )
 
 target_include_directories(projectM_ns-eel2
-        PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/projectm-eel>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval/ns-eel2>
-        )
+                           PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+                           $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/projectm-eel>
+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval/ns-eel2>
+                           )
 
 target_link_libraries(projectM_ns-eel2
-        PUBLIC
-        projectM::Eval
-        )
+                      PUBLIC
+                      projectM::Eval
+                      )
 
 set_target_properties(projectM_ns-eel2 PROPERTIES
-        EXPORT_NAME ns-eel2
-        )
+                      EXPORT_NAME ns-eel2
+                      )
 
 add_library(projectM::ns-eel2 ALIAS projectM_ns-eel2)
 
-install(TARGETS projectM_ns-eel2
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        EXPORT projectM-EvalMilkdrop
-        )
+if(ENABLE_PROJECTM_EVAL_INSTALL)
 
-install(FILES ns-eel.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval/ns-eel2
-        )
+    install(TARGETS projectM_ns-eel2
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            EXPORT projectM-EvalMilkdrop
+            )
 
-# For use from an installed package (system install, vcpkg, homebrew etc.)
-include(CMakePackageConfigHelpers)
+    install(FILES ns-eel.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval/ns-eel2
+            )
 
-write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfigVersion.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY AnyNewerVersion
-        )
+    # For use from an installed package (system install, vcpkg, homebrew etc.)
+    include(CMakePackageConfigHelpers)
 
-configure_package_config_file(projectM-EvalMilkdropConfig.cmake.in
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfig.cmake"
-        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-EvalMilkdrop"
-        PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR
-        )
+    write_basic_package_version_file(
+            "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfigVersion.cmake"
+            VERSION ${PROJECT_VERSION}
+            COMPATIBILITY AnyNewerVersion
+            )
 
-install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfigVersion.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfig.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-EvalMilkdrop"
-        COMPONENT Devel
-        )
+    configure_package_config_file(projectM-EvalMilkdropConfig.cmake.in
+                                  "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfig.cmake"
+                                  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-EvalMilkdrop"
+                                  PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR
+                                  )
 
-install(EXPORT projectM-EvalMilkdrop
-        FILE projectM-EvalMilkdropTargets.cmake
-        NAMESPACE projectM::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-EvalMilkdrop"
-        COMPONENT Devel
-        )
+    install(FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfigVersion.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/projectM-EvalMilkdrop/projectM-EvalMilkdropConfig.cmake"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-EvalMilkdrop"
+            COMPONENT Devel
+            )
+
+    install(EXPORT projectM-EvalMilkdrop
+            FILE projectM-EvalMilkdropTargets.cmake
+            NAMESPACE projectM::
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-EvalMilkdrop"
+            COMPONENT Devel
+            )
+
+endif()

--- a/projectm-eval/CMakeLists.txt
+++ b/projectm-eval/CMakeLists.txt
@@ -1,127 +1,131 @@
 
 set(BISON_OUTPUT_FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/Compiler.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/Compiler.h
-        )
+    ${CMAKE_CURRENT_SOURCE_DIR}/Compiler.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Compiler.h
+    )
 
 set(FLEX_OUTPUT_FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/Scanner.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/Scanner.h
-        )
+    ${CMAKE_CURRENT_SOURCE_DIR}/Scanner.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Scanner.h
+    )
 
-if (FLEX_FOUND)
+if(FLEX_FOUND)
     # Generate lexer code
     add_custom_command(COMMAND ${FLEX_EXECUTABLE}
-            --noline
-            --prefix=prjm_eval_
-            --header-file=Scanner.h
-            -o Scanner.c
-            Scanner.l
-            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-            OUTPUT ${FLEX_OUTPUT_FILES}
-            DEPENDS Scanner.l
-            )
+                       --noline
+                       --prefix=prjm_eval_
+                       --header-file=Scanner.h
+                       -o Scanner.c
+                       Scanner.l
+                       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                       OUTPUT ${FLEX_OUTPUT_FILES}
+                       DEPENDS Scanner.l
+                       )
 
     add_custom_target(GenerateScanner ALL
-            DEPENDS ${FLEX_OUTPUT_FILES}
-            )
-endif ()
+                      DEPENDS ${FLEX_OUTPUT_FILES}
+                      )
+endif()
 
-if (BISON_FOUND)
+if(BISON_FOUND)
     # Generate compiler code
     add_custom_command(COMMAND ${BISON_EXECUTABLE}
-            --defines=Compiler.h
-            -Wcounterexamples
-            --no-lines
-            -o Compiler.c
-            Compiler.y
-            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-            OUTPUT ${BISON_OUTPUT_FILES}
-            DEPENDS Compiler.y
-            )
+                       --defines=Compiler.h
+                       -Wcounterexamples
+                       --no-lines
+                       -o Compiler.c
+                       Compiler.y
+                       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                       OUTPUT ${BISON_OUTPUT_FILES}
+                       DEPENDS Compiler.y
+                       )
 
     add_custom_target(GenerateCompiler ALL
-            DEPENDS ${BISON_OUTPUT_FILES}
-            )
-endif ()
+                      DEPENDS ${BISON_OUTPUT_FILES}
+                      )
+endif()
 
 add_library(projectM_eval STATIC
-        ${BISON_OUTPUT_FILES}
-        ${FLEX_OUTPUT_FILES}
-        CompileContext.c
-        CompileContext.h
-        Compiler.y
-        CompilerFunctions.c
-        CompilerFunctions.h
-        CompilerTypes.h
-        ExpressionTree.c
-        ExpressionTree.h
-        MemoryBuffer.c
-        MemoryBuffer.h
-        Scanner.l
-        TreeFunctions.c
-        TreeFunctions.h
-        TreeVariables.c
-        TreeVariables.h
-        api/projectm-eval.c
-        api/projectm-eval.h
-        )
+            ${BISON_OUTPUT_FILES}
+            ${FLEX_OUTPUT_FILES}
+            CompileContext.c
+            CompileContext.h
+            Compiler.y
+            CompilerFunctions.c
+            CompilerFunctions.h
+            CompilerTypes.h
+            ExpressionTree.c
+            ExpressionTree.h
+            MemoryBuffer.c
+            MemoryBuffer.h
+            Scanner.l
+            TreeFunctions.c
+            TreeFunctions.h
+            TreeVariables.c
+            TreeVariables.h
+            api/projectm-eval.c
+            api/projectm-eval.h
+            )
 
 target_include_directories(projectM_eval
-        PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval>
-        )
+                           PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval>
+                           )
 
 set_target_properties(projectM_eval PROPERTIES
-        EXPORT_NAME Eval
-        )
+                      EXPORT_NAME Eval
+                      )
 
-if (NOT NO_MATH_LIB_REQUIRED)
+if(NOT NO_MATH_LIB_REQUIRED)
     target_link_libraries(projectM_eval
-            INTERFACE
-            m
-            )
-endif ()
+                          INTERFACE
+                          m
+                          )
+endif()
 
 add_library(projectM::Eval ALIAS projectM_eval)
 
-install(TARGETS projectM_eval
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        EXPORT projectM-Eval
-        )
+if(ENABLE_PROJECTM_EVAL_INSTALL)
 
-install(FILES api/projectm-eval.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval/
-        )
+    install(TARGETS projectM_eval
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            EXPORT projectM-Eval
+            )
+
+    install(FILES api/projectm-eval.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/projectm-eval/
+            )
 
 
-# For use from an installed package (system install, vcpkg, homebrew etc.)
-include(CMakePackageConfigHelpers)
+    # For use from an installed package (system install, vcpkg, homebrew etc.)
+    include(CMakePackageConfigHelpers)
 
-write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfigVersion.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY AnyNewerVersion
-)
+    write_basic_package_version_file(
+            "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfigVersion.cmake"
+            VERSION ${PROJECT_VERSION}
+            COMPATIBILITY AnyNewerVersion
+            )
 
-configure_package_config_file(projectM-EvalConfig.cmake.in
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfig.cmake"
-        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-Eval"
-        PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR
-        )
+    configure_package_config_file(projectM-EvalConfig.cmake.in
+                                  "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfig.cmake"
+                                  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-Eval"
+                                  PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR
+                                  )
 
-install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfigVersion.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfig.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-Eval"
-        COMPONENT Devel
-        )
+    install(FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfigVersion.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/projectM-Eval/projectM-EvalConfig.cmake"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-Eval"
+            COMPONENT Devel
+            )
 
-install(EXPORT projectM-Eval
-        FILE projectM-EvalTargets.cmake
-        NAMESPACE projectM::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-Eval"
-        COMPONENT Devel
-        )
+    install(EXPORT projectM-Eval
+            FILE projectM-EvalTargets.cmake
+            NAMESPACE projectM::
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/projectM-Eval"
+            COMPONENT Devel
+            )
+
+endif()


### PR DESCRIPTION
Instead, added an option ENABLE_PROJECTM_EVAL_INSTALL devs can set if they still want to install the files.