### PR TITLE
Fix mismatched declaration of yyerror function.

### DIFF
--- a/projectm-eval/Compiler.h
+++ b/projectm-eval/Compiler.h
@@ -147,7 +147,7 @@ int prjm_eval_parse (prjm_eval_compiler_context_t* cctx, yyscan_t scanner);
        int yylex(YYSTYPE* yylval_param, YYLTYPE* yylloc_param, prjm_eval_compiler_context_t* cctx, yyscan_t yyscanner)
    YY_DECL;
 
-   int yyerror(YYLTYPE* yyllocp, prjm_eval_compiler_context_t* cctx, yyscan_t yyscanner, const char* message);
+   void yyerror(YYLTYPE* yyllocp, prjm_eval_compiler_context_t* cctx, yyscan_t yyscanner, const char* message);
 
 
 #endif /* !YY_PRJM_EVAL_COMPILER_H_INCLUDED  */

--- a/projectm-eval/Compiler.y
+++ b/projectm-eval/Compiler.y
@@ -30,7 +30,7 @@ typedef void* yyscan_t;
        int yylex(YYSTYPE* yylval_param, YYLTYPE* yylloc_param, prjm_eval_compiler_context_t* cctx, yyscan_t yyscanner)
    YY_DECL;
 
-   int yyerror(YYLTYPE* yyllocp, prjm_eval_compiler_context_t* cctx, yyscan_t yyscanner, const char* message);
+   void yyerror(YYLTYPE* yyllocp, prjm_eval_compiler_context_t* cctx, yyscan_t yyscanner, const char* message);
 }
 
 /* Token declarations */


### PR DESCRIPTION
Just a small fix. Bison's yyerror function has a `void` return type, somehow an `int` return type crept into the .y file. To make it even more confusing is that most compilers seem to ignore this and still happily compile the code.