### PR TITLE
Fix a memory leak caused by calling the wrong destroy function.

### DIFF
--- a/projectm-eval/api/projectm-eval.c
+++ b/projectm-eval/api/projectm-eval.c
@@ -12,7 +12,7 @@ projectm_eval_mem_buffer projectm_eval_memory_buffer_create()
 
 void projectm_eval_memory_buffer_destroy(projectm_eval_mem_buffer buffer)
 {
-    prjm_eval_memory_free(buffer);
+    prjm_eval_memory_destroy_buffer(buffer);
 }
 
 void projectm_eval_memory_global_destroy()


### PR DESCRIPTION
Called the non-buffer destroy function, resulting in not all memory being free'd.