### PR TITLE
Document numerical constants in Expression-Syntax.md

### DIFF
--- a/docs/Compiler-Internals.md
+++ b/docs/Compiler-Internals.md
@@ -21,7 +21,7 @@ scanner looks for these kinds of symbols, with letters always being case-insensi
 - Numbers in integer and floating-point notation with an optional exponent. Note that these numbers are always positive,
   negativity is applied later via the `-` unary operator in the parser.
 - Identifiers starting with an underscore or alphabetical letter, and also numbers on any following character.
-  These can be returned as two diffent tokens:
+  These can be returned as two different tokens:
     - If the (lower-case) name exists in the function table, the name is returned as a `FUN` token.
     - Anything else is returned as a `VAR` token and identifies a variable.
 
@@ -140,7 +140,7 @@ type `prjm_eval_compiler_node`, which stores a few additional flags only require
 #### Function Argument List
 
 Inside a function argument list, all expressions are collected in a special `prjm_eval_compiler_arg_list` wrapper holding
-one compiler node object for each potential function argument. It also keeps the arugment count as a separate variable
+one compiler node object for each potential function argument. It also keeps the argument count as a separate variable
 for easy access.
 
 When the arguments have been collected and the function is reduced in the parser, the action will then compare the

--- a/docs/Expression-Syntax.md
+++ b/docs/Expression-Syntax.md
@@ -84,6 +84,41 @@ local scope as any other variable. The same is true for more digits like `reg123
 Same as with gmegabuf, global variables are not necessarily `0` when a preset is initialized and they can change at any
 time when two presets using the same global variables are blended during a transition.
 
+### Constants
+
+All constants are converted into floating-point numbers internally, even if written as integers.
+
+As with all other names, constant names (and hexadecimal values) are also case-insensitive.
+
+#### Numerical Constants
+
+Basic numerical/decimal constants can be defined in the code in the following formats:
+
+- Integer values: `1` (or `1.`)
+- Decimal values: `1.234` (values between 0 and 1 can be abbreviated with `.234`, which equals `0.234`)
+- Base 10 exponential form: `1.234e5` equals `123400` and `1.234e-5` equals `0.00001234`
+
+#### Predefined Constants
+
+A few named convenience constants can be used:
+
+- `$PI`: Equals `3.141592653589793`
+- `$E`: Equals `2.71828183`
+- `$PHI`: Equals `1.61803399`
+
+#### Hexadecimal Constants
+
+Hexadecimal constants start with `$X`, immediately followed by the hexadecimal numbers.
+
+Example: `$XFF` converts to `255`.
+
+#### Character (Ordinal) Constants
+
+Constants can also convert a single character into its ordinal (ASCII) value using the form `$'c'`, where `c` is the
+character to convert.
+
+Example: `$'a'` converts to `97`.
+
 ### Operator Precedence
 
 Operator precedence is defined in a similar way as in C, with the expection of the `^` operator, which has a different

--- a/docs/Expression-Syntax.md
+++ b/docs/Expression-Syntax.md
@@ -59,7 +59,7 @@ z = sin(4.0);
 
 ### Variable and Function Names, Limits
 
-Variable and function names are generally case-insensitve, making `variable` equivalent to `vArIaBlE`.
+Variable and function names are generally case-insensitive, making `variable` equivalent to `vArIaBlE`.
 
 Any text in expressions - starting with either a letter from a to z or an underscore, followed by more of these
 characters and also numbers from 0 to 9 - is first checked to be a built-in function. If it is not a function, the
@@ -81,7 +81,7 @@ in the same way as gmegabuf.
 Note the index must always be written with two digits. `reg3` is _not_ considered a global variable and will only have a
 local scope as any other variable. The same is true for more digits like `reg123`.
 
-Same as with gmegabuf, global variables are not necessarily `0` when a preset is initialized and they can change at any
+Same as with gmegabuf, global variables are not necessarily `0` when a preset is initialized, and they can change at any
 time when two presets using the same global variables are blended during a transition.
 
 ### Constants
@@ -121,7 +121,7 @@ Example: `$'a'` converts to `97`.
 
 ### Operator Precedence
 
-Operator precedence is defined in a similar way as in C, with the expection of the `^` operator, which has a different
+Operator precedence is defined in a similar way as in C, except the `^` operator, which has a different
 meaning in Milkdrop presets (pow() instead of binary XOR).
 
 See the [C precedence table on cppreference.com](https://en.cppreference.com/w/c/language/operator_precedence) for
@@ -176,7 +176,7 @@ if(x > 5,5000,1000)[(sin(y) + 1 * .5) * 1000] = z;
 ### Using Parentheses
 
 Parentheses can be used to specify a specific order in which operations are executed. Expressions inside parentheses are
-always evaluated, and the result of the evaluation is then uses to evaluate any outside expression.
+always evaluated, and the result of the evaluation is then used to evaluate any outside expression.
 
 Inside parentheses, using expression lists is also valid. The result is, as described above, the value of the last
 expression in the list. For example, the following expression will use `5` as the return value:
@@ -515,7 +515,7 @@ level, which can hang up the application.
 ### Internal Functions and Aliases
 
 The following functions are defined internally, some being aliases to the above functions, others being used as actual
-implementations of operators. Deoending on the operator being unary or binary, each function has one or two parameters.
+implementations of operators. Depending on the operator being unary or binary, each function has one or two parameters.
 
 - _aboeq => Operator `>=`
 - _above => Operator `>`


### PR DESCRIPTION
Added missing documentation for `$` constants plus (self-explanatory) numerical constant usage, except maybe the exponential syntax which is also supported by Milkdrop but was never documented.