### PR TITLE
Generate and install pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 8 AND NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 4
 endif()
 
 project(projectm-eval
-        VERSION 1.0.0
+        VERSION 1.0.1
         LANGUAGES ${LANGUAGES} # Using "enable_language(CXX)" in the test dir will NOT work properly!
         )
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -72,12 +72,12 @@ or library:
 
 ```cmake
 add_executable(MyApp
-        # Sources go here
-        )
+    # Sources go here
+)
 target_link_libraries(MyApp
-        PRIVATE
-        projectM::Eval
-        )
+    PRIVATE
+    projectM::Eval
+)
 ```
 
 Important: If your final target is a static library, this will _not_ copy any code into it! Any application using this
@@ -104,12 +104,12 @@ variant. To link the library as a static library, the CMake code is identical:
 
 ```cmake
 add_executable(MyApp
-        # Sources go here
-        )
+    # Sources go here
+)
 target_link_libraries(MyApp
-        PRIVATE
-        projectM::Eval
-        )
+    PRIVATE
+    projectM::Eval
+)
 ```
 
 If the target is a static library, to which the projectM-Eval object files should be added, then an additional line in
@@ -117,13 +117,13 @@ the target source list is required:
 
 ```cmake
 add_library(MyLib STATIC
-        $<TARGET_OBJECTS:projectM::Eval>
-        # Other sources go here
-        )
+    $<TARGET_OBJECTS:projectM::Eval>
+    # Other sources go here
+)
 target_link_libraries(MyApp
-        PRIVATE
-        projectM::Eval
-        )
+    PRIVATE
+    projectM::Eval
+)
 ```
 
 Note that the library still needs to be linked. While this won't add any code to the target, it will populate the
@@ -133,6 +133,11 @@ required include directories and compiler flags needed to use the headers.
 
 If CMake is not an option, the static library can be linked manually and the `projectm-eval.h` header file can be copied
 into the project or pointed to via the include directory settings of the build system used.
+
+On UNIX operating systems such as Linux, macOS or BSD and if `ENABLE_PROJECTM_EVAL_INSTALL` is enabled, a
+`projectm-eval.pc` pkg-config file will be installed into the destination library dir and can be used by any
+pkg-config-compatible build system to link the static library (using `pkg-config --libs projectm-eval`) and retrieve the
+correct include dir (using `pkg-config --cflags projectm-eval`).
 
 To use it as an object library, please refer to the platform build tools on how to unpack the static library into its
 object files or how to copy its contents into another static library.

--- a/projectm-eval/CMakeLists.txt
+++ b/projectm-eval/CMakeLists.txt
@@ -128,4 +128,11 @@ if(ENABLE_PROJECTM_EVAL_INSTALL)
             COMPONENT Devel
             )
 
+    # Install pkgconfig file
+    if(UNIX)
+        configure_file(install-pkgconfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/install-pkgconfig.cmake @ONLY)
+        install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/install-pkgconfig.cmake
+            COMPONENT Devel
+        )
+    endif()
 endif()

--- a/projectm-eval/install-pkgconfig.cmake.in
+++ b/projectm-eval/install-pkgconfig.cmake.in
@@ -1,0 +1,7 @@
+# pkg-config file install script. Executed during install phase of the library.
+
+set(CMAKE_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")
+set(CMAKE_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_INCLUDEDIR@")
+set(PROJECT_VERSION "@PROJECT_VERSION@")
+set(PROJECTM_EVAL_FLOAT_SIZE "@PROJECTM_EVAL_FLOAT_SIZE@")
+configure_file(@CMAKE_CURRENT_SOURCE_DIR@/projectm-eval.pc.in ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/projectm-eval.pc @ONLY)

--- a/projectm-eval/projectm-eval.pc.in
+++ b/projectm-eval/projectm-eval.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+pkgdatadir=${prefix}/
+sysconfdir=${prefix}/
+
+Name: projectm-eval
+Version: @PROJECT_VERSION@
+Description: projectM Expression Evaluation Library
+Libs: -L${libdir} -l:projectM_eval
+Cflags: -I${includedir} -DPRJM_F_SIZE=@PROJECTM_EVAL_FLOAT_SIZE@


### PR DESCRIPTION
When compiling/installing projectm-eval as a separate library, e.g. when building in vcpkg or Homebrew, creating a pkg-config file alongside the CMake files will make it easier for other build systems to use it.