### PR TITLE
Fix AND and OR operators

### DIFF
--- a/.github/workflows/build_emscripten.yml
+++ b/.github/workflows/build_emscripten.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v11
+        uses: mymindstorm/setup-emsdk@v14
         with:
           # Make sure to set a version number!
-          version: 3.1.53
+          version: 3.1.74
           # This is the name of the cache folder.
           # The cache folder will be placed in the build directory,
           #  so make sure it doesn't conflict with anything!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 8 AND NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 4
 endif()
 
 project(projectm-eval
-        VERSION 1.0.1
+        VERSION 1.0.2
         LANGUAGES ${LANGUAGES} # Using "enable_language(CXX)" in the test dir will NOT work properly!
         )
 

--- a/projectm-eval/Compiler.c
+++ b/projectm-eval/Compiler.c
@@ -2008,11 +2008,11 @@ yyreduce:
     break;
 
   case 33: /* expression: expression BOOLOR expression  */
-                                               { PRJM_EVAL_FUNC2((yyval.expression), "bor", (yyvsp[-2].expression), (yyvsp[0].expression)) }
+                                               { PRJM_EVAL_FUNC2((yyval.expression), "_or", (yyvsp[-2].expression), (yyvsp[0].expression)) }
     break;
 
   case 34: /* expression: expression BOOLAND expression  */
-                                               { PRJM_EVAL_FUNC2((yyval.expression), "band", (yyvsp[-2].expression), (yyvsp[0].expression)) }
+                                               { PRJM_EVAL_FUNC2((yyval.expression), "_and", (yyvsp[-2].expression), (yyvsp[0].expression)) }
     break;
 
   case 35: /* expression: expression '=' expression  */
@@ -2052,11 +2052,11 @@ yyreduce:
     break;
 
   case 44: /* expression: expression '|' expression  */
-                                         { PRJM_EVAL_FUNC2((yyval.expression), "bor", (yyvsp[-2].expression), (yyvsp[0].expression)) }
+                                         { PRJM_EVAL_FUNC2((yyval.expression), "/*or*/", (yyvsp[-2].expression), (yyvsp[0].expression)) }
     break;
 
   case 45: /* expression: expression '&' expression  */
-                                         { PRJM_EVAL_FUNC2((yyval.expression), "band", (yyvsp[-2].expression), (yyvsp[0].expression)) }
+                                         { PRJM_EVAL_FUNC2((yyval.expression), "/*and*/", (yyvsp[-2].expression), (yyvsp[0].expression)) }
     break;
 
   case 46: /* expression: '-' expression  */

--- a/projectm-eval/Compiler.y
+++ b/projectm-eval/Compiler.y
@@ -145,8 +145,8 @@ expression:
 | expression[left] '>' expression[right]       { PRJM_EVAL_FUNC2($$, "_above", $left, $right) }
 
 /* Boolean operators */
-| expression[left] BOOLOR expression[right]    { PRJM_EVAL_FUNC2($$, "bor", $left, $right) }
-| expression[left] BOOLAND expression[right]   { PRJM_EVAL_FUNC2($$, "band", $left, $right) }
+| expression[left] BOOLOR expression[right]    { PRJM_EVAL_FUNC2($$, "_or", $left, $right) }
+| expression[left] BOOLAND expression[right]   { PRJM_EVAL_FUNC2($$, "_and", $left, $right) }
 
 /* Assignment operator */
 | expression[left] '=' expression[right]           { PRJM_EVAL_FUNC2($$, "_set", $left, $right) }
@@ -164,8 +164,8 @@ expression:
 | expression[left] '/' expression[right] { PRJM_EVAL_FUNC2($$, "_div", $left, $right) }
 | expression[left] '%' expression[right] { PRJM_EVAL_FUNC2($$, "_mod", $left, $right) }
 | expression[left] '^' expression[right] { PRJM_EVAL_FUNC2($$, "pow", $left, $right) }
-| expression[left] '|' expression[right] { PRJM_EVAL_FUNC2($$, "bor", $left, $right) }
-| expression[left] '&' expression[right] { PRJM_EVAL_FUNC2($$, "band", $left, $right) }
+| expression[left] '|' expression[right] { PRJM_EVAL_FUNC2($$, "/*or*/", $left, $right) }
+| expression[left] '&' expression[right] { PRJM_EVAL_FUNC2($$, "/*and*/", $left, $right) }
 
 /* Unary operators */
 | '-' expression[value] %prec NEG        { PRJM_EVAL_FUNC1($$, "_neg", $value) }

--- a/projectm-eval/Scanner.c
+++ b/projectm-eval/Scanner.c
@@ -1546,11 +1546,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-{ return '%'; }
+{ return '&'; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-{ return '^'; }
+{ return '|'; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP

--- a/projectm-eval/Scanner.l
+++ b/projectm-eval/Scanner.l
@@ -105,8 +105,8 @@ NAME            [_a-zA-Z][_a-zA-Z0-9]*
 "/"                 { return '/'; }
 "%"                 { return '%'; }
 "^"	                { return '^'; }
-"&"                 { return '%'; }
-"|"	                { return '^'; }
+"&"                 { return '&'; }
+"|"	                { return '|'; }
 "!"	                { return '!'; }
 "="	                { return '='; }
 

--- a/projectm-eval/TreeFunctions.c
+++ b/projectm-eval/TreeFunctions.c
@@ -21,6 +21,8 @@ static prjm_eval_function_def_t intrinsic_function_table[] = {
     { "/*const*/", prjm_eval_func_const,         0, true,  false },
     { "/*var*/",   prjm_eval_func_var,           0, false, false },
     { "/*list*/",  prjm_eval_func_execute_list,  1, true,  false },
+    { "/*or*/",    prjm_eval_func_or,            2, true, false },
+    { "/*and*/",   prjm_eval_func_and,           2, true, false },
 
     { "if",        prjm_eval_func_if,            3, true,  false },
     { "_if",       prjm_eval_func_if,            3, true,  false },
@@ -777,6 +779,21 @@ prjm_eval_function_decl(orop)
     assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) | (int)(*val2_ptr)));
 }
 
+prjm_eval_function_decl(or)
+{
+    assert_valid_ctx();
+
+    PRJM_EVAL_F val1 = .0;
+    PRJM_EVAL_F* val1_ptr = &val1;
+    PRJM_EVAL_F val2 = .0;
+    PRJM_EVAL_F* val2_ptr = &val2;
+
+    invoke_arg(0, &val1_ptr);
+    invoke_arg(1, &val2_ptr);
+
+    assign_ret_val((PRJM_EVAL_F) ((int)(*val1_ptr) | (int)(*val2_ptr)));
+}
+
 prjm_eval_function_decl(andop)
 {
     assert_valid_ctx();
@@ -788,6 +805,21 @@ prjm_eval_function_decl(andop)
     invoke_arg(1, &val2_ptr);
 
     assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) & (int)(*val2_ptr)));
+}
+
+prjm_eval_function_decl(and)
+{
+    assert_valid_ctx();
+
+    PRJM_EVAL_F val1 = .0;
+    PRJM_EVAL_F* val1_ptr = &val1;
+    PRJM_EVAL_F val2 = .0;
+    PRJM_EVAL_F* val2_ptr = &val2;
+
+    invoke_arg(0, &val1_ptr);
+    invoke_arg(1, &val2_ptr);
+
+    assign_ret_val((PRJM_EVAL_F) ((int)(*val1_ptr) & (int)(*val2_ptr)));
 }
 
 prjm_eval_function_decl(modop)

--- a/projectm-eval/TreeFunctions.c
+++ b/projectm-eval/TreeFunctions.c
@@ -18,85 +18,85 @@
  */
 static prjm_eval_function_def_t intrinsic_function_table[] = {
     /* Special intrinsic functions. Cannot be used via expression syntax. */
-    { "/*const*/", prjm_eval_func_const,         0, true,  false },
-    { "/*var*/",   prjm_eval_func_var,           0, false, false },
-    { "/*list*/",  prjm_eval_func_execute_list,  1, true,  false },
-    { "/*or*/",    prjm_eval_func_or,            2, true, false },
-    { "/*and*/",   prjm_eval_func_and,           2, true, false },
+    { "/*const*/", prjm_eval_func_const,            0, true,  false },
+    { "/*var*/",   prjm_eval_func_var,              0, false, false },
+    { "/*list*/",  prjm_eval_func_execute_list,     1, true,  false },
+    { "/*or*/",    prjm_eval_func_bitwise_or,       2, true,  false },
+    { "/*and*/",   prjm_eval_func_bitwise_and,      2, true,  false },
 
-    { "if",        prjm_eval_func_if,            3, true,  false },
-    { "_if",       prjm_eval_func_if,            3, true,  false },
-    { "_and",      prjm_eval_func_band_op,       2, true,  false },
-    { "_or",       prjm_eval_func_bor_op,        2, true,  false },
-    { "loop",      prjm_eval_func_execute_loop,  2, true,  false },
-    { "while",     prjm_eval_func_execute_while, 1, true,  false },
+    { "if",        prjm_eval_func_if,               3, true,  false },
+    { "_if",       prjm_eval_func_if,               3, true,  false },
+    { "_and",      prjm_eval_func_boolean_and_op,   2, true,  false },
+    { "_or",       prjm_eval_func_boolean_or_op,    2, true,  false },
+    { "loop",      prjm_eval_func_execute_loop,     2, true,  false },
+    { "while",     prjm_eval_func_execute_while,    1, true,  false },
 
-    { "_not",      prjm_eval_func_bnot,          1, true,  false },
-    { "bnot",      prjm_eval_func_bnot,         1, true,  false },
-    { "_equal",    prjm_eval_func_equal,        2, true,  false },
-    { "equal",     prjm_eval_func_equal,        2, true,  false },
-    { "_noteq",    prjm_eval_func_notequal,     2, true,  false },
-    { "_below",    prjm_eval_func_below,        2, true,  false },
-    { "below",     prjm_eval_func_below,        2, true,  false },
-    { "_above",    prjm_eval_func_above,        2, true,  false },
-    { "above",     prjm_eval_func_above,        2, true,  false },
-    { "_beleq",    prjm_eval_func_beloweq,      2, true,  false },
-    { "_aboeq",    prjm_eval_func_aboveeq,      2, true,  false },
+    { "_not",      prjm_eval_func_bnot,             1, true,  false },
+    { "bnot",      prjm_eval_func_bnot,             1, true,  false },
+    { "_equal",    prjm_eval_func_equal,            2, true,  false },
+    { "equal",     prjm_eval_func_equal,            2, true,  false },
+    { "_noteq",    prjm_eval_func_notequal,         2, true,  false },
+    { "_below",    prjm_eval_func_below,            2, true,  false },
+    { "below",     prjm_eval_func_below,            2, true,  false },
+    { "_above",    prjm_eval_func_above,            2, true,  false },
+    { "above",     prjm_eval_func_above,            2, true,  false },
+    { "_beleq",    prjm_eval_func_beloweq,          2, true,  false },
+    { "_aboeq",    prjm_eval_func_aboveeq,          2, true,  false },
 
-    { "_set",      prjm_eval_func_set,          2, false, true },
-    { "assign",    prjm_eval_func_set,          2, false, true },
-    { "_add",      prjm_eval_func_add,          2, true,  false },
-    { "_sub",      prjm_eval_func_sub,          2, true,  false },
-    { "_mul",      prjm_eval_func_mul,          2, true,  false },
-    { "_div",      prjm_eval_func_div,          2, true,  false },
-    { "_mod",      prjm_eval_func_mod,          2, true,  false },
-    { "_mulop",    prjm_eval_func_mulop,        2, false, true },
-    { "_divop",    prjm_eval_func_divop,        2, false, true },
-    { "_orop",     prjm_eval_func_orop,         2, false, true },
-    { "_andop",    prjm_eval_func_andop,        2, false, true },
-    { "_addop",    prjm_eval_func_addop,        2, false, true },
-    { "_subop",    prjm_eval_func_subop,        2, false, true },
-    { "_modop",    prjm_eval_func_modop,        2, false, true },
+    { "_set",      prjm_eval_func_set,              2, false, true  },
+    { "assign",    prjm_eval_func_set,              2, false, true  },
+    { "_add",      prjm_eval_func_add,              2, true,  false },
+    { "_sub",      prjm_eval_func_sub,              2, true,  false },
+    { "_mul",      prjm_eval_func_mul,              2, true,  false },
+    { "_div",      prjm_eval_func_div,              2, true,  false },
+    { "_mod",      prjm_eval_func_mod,              2, true,  false },
+    { "_mulop",    prjm_eval_func_mul_op,           2, false, true  },
+    { "_divop",    prjm_eval_func_div_op,           2, false, true  },
+    { "_orop",     prjm_eval_func_bitwise_or_op,    2, false, true  },
+    { "_andop",    prjm_eval_func_bitwise_and_op,   2, false, true  },
+    { "_addop",    prjm_eval_func_add_op,           2, false, true  },
+    { "_subop",    prjm_eval_func_sub_op,           2, false, true  },
+    { "_modop",    prjm_eval_func_mod_op,           2, false, true  },
 
-    { "sin",       prjm_eval_func_sin,          1, true,  false },
-    { "cos",       prjm_eval_func_cos,          1, true,  false },
-    { "tan",       prjm_eval_func_tan,          1, true,  false },
-    { "asin",      prjm_eval_func_asin,         1, true,  false },
-    { "acos",      prjm_eval_func_acos,         1, true,  false },
-    { "atan",      prjm_eval_func_atan,         1, true,  false },
-    { "atan2",     prjm_eval_func_atan2,        2, true,  false },
-    { "sqr",       prjm_eval_func_sqr,          1, true,  false },
-    { "sqrt",      prjm_eval_func_sqrt,         1, true,  false },
-    { "pow",       prjm_eval_func_pow,          2, true,  false },
-    { "_powop",    prjm_eval_func_powop,        2, false, true },
-    { "exp",       prjm_eval_func_exp,          1, true,  false },
-    { "_neg",      prjm_eval_func_neg,          1, true,  false },
+    { "sin",       prjm_eval_func_sin,              1, true,  false },
+    { "cos",       prjm_eval_func_cos,              1, true,  false },
+    { "tan",       prjm_eval_func_tan,              1, true,  false },
+    { "asin",      prjm_eval_func_asin,             1, true,  false },
+    { "acos",      prjm_eval_func_acos,             1, true,  false },
+    { "atan",      prjm_eval_func_atan,             1, true,  false },
+    { "atan2",     prjm_eval_func_atan2,            2, true,  false },
+    { "sqr",       prjm_eval_func_sqr,              1, true,  false },
+    { "sqrt",      prjm_eval_func_sqrt,             1, true,  false },
+    { "pow",       prjm_eval_func_pow,              2, true,  false },
+    { "_powop",    prjm_eval_func_pow_op,           2, false, true  },
+    { "exp",       prjm_eval_func_exp,              1, true,  false },
+    { "_neg",      prjm_eval_func_neg,              1, true,  false },
 
-    { "log",       prjm_eval_func_log,          1, true,  false },
-    { "log10",     prjm_eval_func_log10,        1, true,  false },
-    { "abs",       prjm_eval_func_abs,          1, true,  false },
-    { "min",       prjm_eval_func_min,          2, true,  false },
-    { "max",       prjm_eval_func_max,          2, true,  false },
-    { "sign",      prjm_eval_func_sign,         1, true,  false },
-    { "rand",      prjm_eval_func_rand,         1, false, false },
-    { "floor",     prjm_eval_func_floor,        1, true,  false },
-    { "int",       prjm_eval_func_floor,        1, true,  false },
-    { "ceil",      prjm_eval_func_ceil,         1, true,  false },
-    { "invsqrt",   prjm_eval_func_invsqrt,      1, true,  false },
-    { "sigmoid",   prjm_eval_func_sigmoid,      2, true,  false },
+    { "log",       prjm_eval_func_log,              1, true,  false },
+    { "log10",     prjm_eval_func_log10,            1, true,  false },
+    { "abs",       prjm_eval_func_abs,              1, true,  false },
+    { "min",       prjm_eval_func_min,              2, true,  false },
+    { "max",       prjm_eval_func_max,              2, true,  false },
+    { "sign",      prjm_eval_func_sign,             1, true,  false },
+    { "rand",      prjm_eval_func_rand,             1, false, false },
+    { "floor",     prjm_eval_func_floor,            1, true,  false },
+    { "int",       prjm_eval_func_floor,            1, true,  false },
+    { "ceil",      prjm_eval_func_ceil,             1, true,  false },
+    { "invsqrt",   prjm_eval_func_invsqrt,          1, true,  false },
+    { "sigmoid",   prjm_eval_func_sigmoid,          2, true,  false },
 
-    { "band",      prjm_eval_func_band_func,    2, true,  false },
-    { "bor",       prjm_eval_func_bor_func,     2, true,  false },
+    { "band",      prjm_eval_func_boolean_and_func, 2, true,  false },
+    { "bor",       prjm_eval_func_boolean_or_func,  2, true,  false },
 
-    { "exec2",     prjm_eval_func_exec2,         2, true,  false },
-    { "exec3",     prjm_eval_func_exec3,         3, true,  false },
-    { "_mem",      prjm_eval_func_mem,           1, false, true },
-    { "megabuf",   prjm_eval_func_mem,           1, false, true },
-    { "_gmem",     prjm_eval_func_mem,           1, false, true },
-    { "gmegabuf",  prjm_eval_func_mem,           1, false, true },
-    { "freembuf",  prjm_eval_func_freembuf,      1, false, true },
-    { "memcpy",    prjm_eval_func_memcpy,        3, false, true },
-    { "memset",    prjm_eval_func_memset,        3, false, true }
+    { "exec2",     prjm_eval_func_exec2,            2, true,  false },
+    { "exec3",     prjm_eval_func_exec3,            3, true,  false },
+    { "_mem",      prjm_eval_func_mem,              1, false, true  },
+    { "megabuf",   prjm_eval_func_mem,              1, false, true  },
+    { "_gmem",     prjm_eval_func_mem,              1, false, true  },
+    { "gmegabuf",  prjm_eval_func_mem,              1, false, true  },
+    { "freembuf",  prjm_eval_func_freembuf,         1, false, true  },
+    { "memcpy",    prjm_eval_func_memcpy,           3, false, true  },
+    { "memset",    prjm_eval_func_memset,           3, false, true  }
 };
 
 
@@ -610,7 +610,7 @@ prjm_eval_function_decl(mod)
     assign_ret_val((PRJM_EVAL_F) ((int) *val1_ptr % divisor));
 }
 
-prjm_eval_function_decl(band_op)
+prjm_eval_function_decl(boolean_and_op)
 {
     assert_valid_ctx();
 
@@ -637,7 +637,7 @@ prjm_eval_function_decl(band_op)
     }
 }
 
-prjm_eval_function_decl(bor_op)
+prjm_eval_function_decl(boolean_or_op)
 {
     assert_valid_ctx();
 
@@ -664,7 +664,7 @@ prjm_eval_function_decl(bor_op)
     }
 }
 
-prjm_eval_function_decl(band_func)
+prjm_eval_function_decl(boolean_and_func)
 {
     assert_valid_ctx();
 
@@ -680,7 +680,7 @@ prjm_eval_function_decl(band_func)
     assign_ret_val(fabs(*val1_ptr) > close_factor && fabs(*val2_ptr) > close_factor ? 1.0 : 0.0);
 }
 
-prjm_eval_function_decl(bor_func)
+prjm_eval_function_decl(boolean_or_func)
 {
     assert_valid_ctx();
 
@@ -708,7 +708,7 @@ prjm_eval_function_decl(neg)
     assign_ret_val(-(*val1_ptr));
 }
 
-prjm_eval_function_decl(addop)
+prjm_eval_function_decl(add_op)
 {
     assert_valid_ctx();
 
@@ -721,7 +721,7 @@ prjm_eval_function_decl(addop)
     assign_ret_val(**ret_val + *val2_ptr);
 }
 
-prjm_eval_function_decl(subop)
+prjm_eval_function_decl(sub_op)
 {
     assert_valid_ctx();
 
@@ -734,7 +734,7 @@ prjm_eval_function_decl(subop)
     assign_ret_val(**ret_val - *val2_ptr);
 }
 
-prjm_eval_function_decl(mulop)
+prjm_eval_function_decl(mul_op)
 {
     assert_valid_ctx();
 
@@ -747,7 +747,7 @@ prjm_eval_function_decl(mulop)
     assign_ret_val(**ret_val * *val2_ptr);
 }
 
-prjm_eval_function_decl(divop)
+prjm_eval_function_decl(div_op)
 {
     assert_valid_ctx();
 
@@ -766,7 +766,7 @@ prjm_eval_function_decl(divop)
     assign_ret_val(**ret_val / *val2_ptr);
 }
 
-prjm_eval_function_decl(orop)
+prjm_eval_function_decl(bitwise_or_op)
 {
     assert_valid_ctx();
 
@@ -779,7 +779,7 @@ prjm_eval_function_decl(orop)
     assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) | (int)(*val2_ptr)));
 }
 
-prjm_eval_function_decl(or)
+prjm_eval_function_decl(bitwise_or)
 {
     assert_valid_ctx();
 
@@ -794,7 +794,7 @@ prjm_eval_function_decl(or)
     assign_ret_val((PRJM_EVAL_F) ((int)(*val1_ptr) | (int)(*val2_ptr)));
 }
 
-prjm_eval_function_decl(andop)
+prjm_eval_function_decl(bitwise_and_op)
 {
     assert_valid_ctx();
 
@@ -807,7 +807,7 @@ prjm_eval_function_decl(andop)
     assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) & (int)(*val2_ptr)));
 }
 
-prjm_eval_function_decl(and)
+prjm_eval_function_decl(bitwise_and)
 {
     assert_valid_ctx();
 
@@ -822,7 +822,7 @@ prjm_eval_function_decl(and)
     assign_ret_val((PRJM_EVAL_F) ((int)(*val1_ptr) & (int)(*val2_ptr)));
 }
 
-prjm_eval_function_decl(modop)
+prjm_eval_function_decl(mod_op)
 {
     assert_valid_ctx();
 
@@ -841,7 +841,7 @@ prjm_eval_function_decl(modop)
     assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) % divisor));
 }
 
-prjm_eval_function_decl(powop)
+prjm_eval_function_decl(pow_op)
 {
     assert_valid_ctx();
 

--- a/projectm-eval/TreeFunctions.h
+++ b/projectm-eval/TreeFunctions.h
@@ -56,23 +56,23 @@ prjm_eval_function_decl(sub);
 prjm_eval_function_decl(mul);
 prjm_eval_function_decl(div);
 prjm_eval_function_decl(mod);
-prjm_eval_function_decl(or);
-prjm_eval_function_decl(and);
-prjm_eval_function_decl(band_op);
-prjm_eval_function_decl(bor_op);
-prjm_eval_function_decl(band_func);
-prjm_eval_function_decl(bor_func);
+prjm_eval_function_decl(bitwise_or);
+prjm_eval_function_decl(bitwise_and);
+prjm_eval_function_decl(boolean_and_op);
+prjm_eval_function_decl(boolean_or_op);
+prjm_eval_function_decl(boolean_and_func);
+prjm_eval_function_decl(boolean_or_func);
 prjm_eval_function_decl(neg);
 
 /* Compound assignment operators */
-prjm_eval_function_decl(addop);
-prjm_eval_function_decl(subop);
-prjm_eval_function_decl(mulop);
-prjm_eval_function_decl(divop);
-prjm_eval_function_decl(modop);
-prjm_eval_function_decl(orop);
-prjm_eval_function_decl(andop);
-prjm_eval_function_decl(powop);
+prjm_eval_function_decl(add_op);
+prjm_eval_function_decl(sub_op);
+prjm_eval_function_decl(mul_op);
+prjm_eval_function_decl(div_op);
+prjm_eval_function_decl(mod_op);
+prjm_eval_function_decl(bitwise_or_op);
+prjm_eval_function_decl(bitwise_and_op);
+prjm_eval_function_decl(pow_op);
 
 /* Mathematical functions */
 prjm_eval_function_decl(sin);

--- a/projectm-eval/TreeFunctions.h
+++ b/projectm-eval/TreeFunctions.h
@@ -56,6 +56,8 @@ prjm_eval_function_decl(sub);
 prjm_eval_function_decl(mul);
 prjm_eval_function_decl(div);
 prjm_eval_function_decl(mod);
+prjm_eval_function_decl(or);
+prjm_eval_function_decl(and);
 prjm_eval_function_decl(band_op);
 prjm_eval_function_decl(bor_op);
 prjm_eval_function_decl(band_func);


### PR DESCRIPTION
There were mistakes on multiple levels:
- The scanner returning the wrong operator symbols for `&` and `|`
- The parser was not adding the correct functions to the tree
- The implementations of the bitwise AND/OR operators (`|` and `&`) were completely missing

Already bumped the version to 1.0.2 in preparation of a new bugfix release.

Thanks to [OfficialIncubo](https://github.com/OfficialIncubo) for finding this issue!