### PR TITLE
Fix sqrt() function returning NaN when...

### DIFF
--- a/projectm-eval/TreeFunctions.c
+++ b/projectm-eval/TreeFunctions.c
@@ -952,7 +952,7 @@ prjm_eval_function_decl(sqrt)
 
     invoke_arg(0, &math_arg_ptr);
 
-    assign_ret_val(sqrt(*math_arg_ptr));
+    assign_ret_val(sqrt(fabs(*math_arg_ptr)));
 }
 
 prjm_eval_function_decl(pow)


### PR DESCRIPTION
...it's using negative numbers.

It returned NaN (not a number) when it calculates the square root with a negative number.
This fix addresses by adding fabs() function inside sqrt() to be 100% equivalent as ns-eel2.
For example: `sqrt(-2)` should do `sqrt(abs(-2))` -> `sqrt(2)` -> `1.4142`.