### PR TITLE
Fix memory leaks on error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 8 AND NOT PROJECTM_EVAL_FLOAT_SIZE EQUAL 4
 endif()
 
 project(projectm-eval
-        VERSION 1.0.3
+        VERSION 1.0.4
         LANGUAGES ${LANGUAGES} # Using "enable_language(CXX)" in the test dir will NOT work properly!
         )
 

--- a/projectm-eval/Compiler.c
+++ b/projectm-eval/Compiler.c
@@ -518,11 +518,11 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    77,    77,    78,    88,    92,    93,    97,   101,   102,
-     103,   107,   108,   114,   115,   118,   121,   122,   123,   130,
-     131,   132,   133,   134,   135,   136,   137,   140,   141,   142,
-     143,   144,   145,   148,   149,   152,   155,   158,   161,   162,
-     163,   164,   165,   166,   167,   168,   171,   172,   173,   176
+       0,    82,    82,    83,    93,    97,    98,   102,   106,   107,
+     108,   112,   113,   119,   120,   123,   126,   127,   128,   135,
+     136,   137,   138,   139,   140,   141,   142,   145,   146,   147,
+     148,   149,   150,   153,   154,   157,   160,   163,   166,   167,
+     168,   169,   170,   171,   172,   173,   176,   177,   178,   181
 };
 #endif
 
@@ -1569,7 +1569,39 @@ yydestruct (const char *yymsg,
   YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YY_USE (yykind);
+  switch (yykind)
+    {
+    case YYSYMBOL_VAR: /* VAR  */
+            { free(((*yyvaluep).VAR)); }
+        break;
+
+    case YYSYMBOL_FUNC: /* FUNC  */
+            { free(((*yyvaluep).FUNC)); }
+        break;
+
+    case YYSYMBOL_function: /* function  */
+            { prjm_eval_compiler_destroy_node(((*yyvaluep).function)); }
+        break;
+
+    case YYSYMBOL_46_function_arglist: /* function-arglist  */
+            { prjm_eval_compiler_destroy_arglist(((*yyvaluep).yykind_46)); }
+        break;
+
+    case YYSYMBOL_parentheses: /* parentheses  */
+            { prjm_eval_compiler_destroy_node(((*yyvaluep).parentheses)); }
+        break;
+
+    case YYSYMBOL_48_instruction_list: /* instruction-list  */
+            { prjm_eval_compiler_destroy_node(((*yyvaluep).yykind_48)); }
+        break;
+
+    case YYSYMBOL_expression: /* expression  */
+            { prjm_eval_compiler_destroy_node(((*yyvaluep).expression)); }
+        break;
+
+      default:
+        break;
+    }
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 

--- a/projectm-eval/Compiler.y
+++ b/projectm-eval/Compiler.y
@@ -47,6 +47,11 @@ typedef void* yyscan_t;
 %nterm <prjm_eval_compiler_node_t*> function program instruction-list expression parentheses
 %nterm <prjm_eval_compiler_arg_list_t*> function-arglist
 
+/* Cleanup */
+%destructor { free($$); } VAR FUNC
+%destructor { prjm_eval_compiler_destroy_node($$); } function instruction-list expression parentheses
+%destructor { prjm_eval_compiler_destroy_arglist($$); } function-arglist
+
 /* Operator precedence, lowest first, highest last. */
 %precedence ','
 %right '='

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(projectM_EvalLib_Test
         PrecedenceTest.cpp
         PrecedenceTest.hpp
         Stubs.cpp
+        SyntaxTest.cpp
+        SyntaxTest.hpp
         TreeFunctionsTest.cpp
         )
 

--- a/tests/SyntaxTest.cpp
+++ b/tests/SyntaxTest.cpp
@@ -1,0 +1,23 @@
+#include "SyntaxTest.hpp"
+
+
+void SyntaxTest::SetUp()
+{
+    m_globalMemory = projectm_eval_memory_buffer_create();
+    m_context = projectm_eval_context_create(m_globalMemory, &m_globalRegisters);
+}
+
+void SyntaxTest::TearDown()
+{
+    projectm_eval_context_destroy(m_context);
+    projectm_eval_memory_buffer_destroy(m_globalMemory);
+    memset(&m_globalRegisters, 0, sizeof(m_globalRegisters));
+}
+
+TEST_F(SyntaxTest, AdditionalLineBreak)
+{
+    auto code = projectm_eval_code_compile(m_context, "k1 =  is_\nbeat*equal(index%2,0);");
+
+    ASSERT_EQ(code, nullptr);
+    ASSERT_STREQ(projectm_eval_get_error(m_context, nullptr, nullptr), "syntax error, unexpected VAR");
+}

--- a/tests/SyntaxTest.hpp
+++ b/tests/SyntaxTest.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <projectm-eval/api/projectm-eval.h>
+
+class SyntaxTest : public testing::Test
+{
+public:
+
+protected:
+
+    void SetUp() override;
+
+    void TearDown() override;
+
+    struct projectm_eval_context* m_context{};
+    projectm_eval_mem_buffer m_globalMemory{};
+    PRJM_EVAL_F m_globalRegisters[100]{};
+};


### PR DESCRIPTION
If a parsing error was encountered, temporary nodes created in that syntax branch weren't properly free'd. Added `%destructor` symbols in the parser definition so the generated parser will now correctly clean up those pointers in case of errors.