### PR TITLE
Use int64_t on all the functions instead of int.

### DIFF
--- a/projectm-eval/TreeFunctions.c
+++ b/projectm-eval/TreeFunctions.c
@@ -265,14 +265,14 @@ prjm_eval_function_decl(execute_loop)
     PRJM_EVAL_F* value_ptr = &ctx->value;
     invoke_arg(0, &value_ptr);
 
-    int loop_count_int = (int) (*value_ptr);
+    int64_t loop_count_int = (int64_t) (*value_ptr);
     /* Limit execution count */
     if (loop_count_int > MAX_LOOP_COUNT)
     {
         loop_count_int = MAX_LOOP_COUNT;
     }
 
-    for (int i = 0; i < loop_count_int; i++)
+    for (int64_t i = 0; i < loop_count_int; i++)
     {
         ctx->value = .0;
         value_ptr = &ctx->value;
@@ -288,7 +288,7 @@ prjm_eval_function_decl(execute_while)
 
     ctx->value = .0;
     PRJM_EVAL_F* value_ptr = &ctx->value;
-    int loop_count_int = MAX_LOOP_COUNT;
+    int64_t loop_count_int = MAX_LOOP_COUNT;
     do
     {
         invoke_arg(0, &value_ptr);
@@ -361,7 +361,7 @@ prjm_eval_function_decl(mem)
     invoke_arg(0, &index_ptr);
 
     // Add 0.0001 to avoid using the wrong index due to tiny float rounding errors.
-    PRJM_EVAL_F* mem_addr = prjm_eval_memory_allocate(ctx->memory_buffer, (int) (*index_ptr + 0.0001));
+    PRJM_EVAL_F* mem_addr = prjm_eval_memory_allocate(ctx->memory_buffer, (int64_t) (*index_ptr + 0.0001));
     if (mem_addr)
     {
         assign_ret_ref(mem_addr);
@@ -379,7 +379,7 @@ prjm_eval_function_decl(freembuf)
     invoke_arg(0, ret_val);
 
     // Add 0.0001 to avoid using the wrong index due to tiny float rounding errors.
-    prjm_eval_memory_free_block(ctx->memory_buffer, (int) (**ret_val + 0.0001));
+    prjm_eval_memory_free_block(ctx->memory_buffer, (int64_t) (**ret_val + 0.0001));
 }
 
 prjm_eval_function_decl(memcpy)
@@ -601,13 +601,13 @@ prjm_eval_function_decl(mod)
     invoke_arg(0, &val1_ptr);
     invoke_arg(1, &val2_ptr);
 
-    int divisor = (int) *val2_ptr;
+    int64_t divisor = (int64_t) *val2_ptr;
     if (divisor == 0)
     {
         assign_ret_val(0.0);
         return;
     }
-    assign_ret_val((PRJM_EVAL_F) ((int) *val1_ptr % divisor));
+    assign_ret_val((PRJM_EVAL_F) ((int64_t) *val1_ptr % divisor));
 }
 
 prjm_eval_function_decl(boolean_and_op)
@@ -776,7 +776,7 @@ prjm_eval_function_decl(bitwise_or_op)
     invoke_arg(0, ret_val);
     invoke_arg(1, &val2_ptr);
 
-    assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) | (int)(*val2_ptr)));
+    assign_ret_val((PRJM_EVAL_F) ((int64_t)(**ret_val) | (int64_t)(*val2_ptr)));
 }
 
 prjm_eval_function_decl(bitwise_or)
@@ -791,7 +791,7 @@ prjm_eval_function_decl(bitwise_or)
     invoke_arg(0, &val1_ptr);
     invoke_arg(1, &val2_ptr);
 
-    assign_ret_val((PRJM_EVAL_F) ((int)(*val1_ptr) | (int)(*val2_ptr)));
+    assign_ret_val((PRJM_EVAL_F) ((int64_t)(*val1_ptr) | (int64_t)(*val2_ptr)));
 }
 
 prjm_eval_function_decl(bitwise_and_op)
@@ -804,7 +804,7 @@ prjm_eval_function_decl(bitwise_and_op)
     invoke_arg(0, ret_val);
     invoke_arg(1, &val2_ptr);
 
-    assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) & (int)(*val2_ptr)));
+    assign_ret_val((PRJM_EVAL_F) ((int64_t)(**ret_val) & (int64_t)(*val2_ptr)));
 }
 
 prjm_eval_function_decl(bitwise_and)
@@ -819,7 +819,7 @@ prjm_eval_function_decl(bitwise_and)
     invoke_arg(0, &val1_ptr);
     invoke_arg(1, &val2_ptr);
 
-    assign_ret_val((PRJM_EVAL_F) ((int)(*val1_ptr) & (int)(*val2_ptr)));
+    assign_ret_val((PRJM_EVAL_F) ((int64_t)(*val1_ptr) & (int64_t)(*val2_ptr)));
 }
 
 prjm_eval_function_decl(mod_op)
@@ -832,13 +832,13 @@ prjm_eval_function_decl(mod_op)
     invoke_arg(0, ret_val);
     invoke_arg(1, &val2_ptr);
 
-    int divisor = (int) *val2_ptr;
+    int64_t divisor = (int64_t) *val2_ptr;
     if (divisor == 0)
     {
         assign_ret_val(0.0);
         return;
     }
-    assign_ret_val((PRJM_EVAL_F) ((int)(**ret_val) % divisor));
+    assign_ret_val((PRJM_EVAL_F) ((int64_t)(**ret_val) % divisor));
 }
 
 prjm_eval_function_decl(pow_op)


### PR DESCRIPTION
Functions that have replaced with int64_t: modulo, bitwise or, bitwise and, memory and execution loops.

For example: This truly fixes the overflow issue on modulo operators while using very high values, e.g. flexi's space voyage
The cause: 983,624,912,364 caused overflow because `int` has a range from `-2,147,483,648` to `2,147,483,647`, while int64_t consists from `-9,223,372,036,854,775,808` to `9,223,372,036,854,775,807`.