### PR TITLE
Fix installed pkgconfig file using wrong linker argument

### DIFF
--- a/projectm-eval/projectm-eval.pc.in
+++ b/projectm-eval/projectm-eval.pc.in
@@ -8,5 +8,5 @@ sysconfdir=${prefix}/
 Name: projectm-eval
 Version: @PROJECT_VERSION@
 Description: projectM Expression Evaluation Library
-Libs: -L${libdir} -l:projectM_eval
+Libs: -L${libdir} -lprojectM_eval
 Cflags: -I${includedir} -DPRJM_F_SIZE=@PROJECTM_EVAL_FLOAT_SIZE@


### PR DESCRIPTION
for some unknown reason I used "-l:<lib>" in the .pc files while it should just be "-l<lib>". This would prevent project-eval from being linked in projects using pkgconfig.